### PR TITLE
Fix for issue-5.

### DIFF
--- a/elasticsearch-head/app.js
+++ b/elasticsearch-head/app.js
@@ -1301,6 +1301,7 @@
 			return $.ajax( $.extend({
 				url: this.base_uri + params.path,
 				dataType: "json",
+				contentType: "application/json",
 				error: function(xhr, type, message) {
 					if("console" in window) {
 						console.log({ "XHR Error": type, "message": message });


### PR DESCRIPTION
Elasticsearch 6 made the 'content-type' header required.  By default, when using $.ajax it sets the 'content-type' header to "application/x-www-form-urlencoded", but it needs to be "application/json".